### PR TITLE
Remove hard coded number of OpenMP threads.

### DIFF
--- a/SLIDE/Network.cpp
+++ b/SLIDE/Network.cpp
@@ -71,7 +71,7 @@ int Network::predictClass(int **inputIndices, float **inputValues, int *length, 
     int correctPred = 0;
 
     auto t1 = std::chrono::high_resolution_clock::now();
-    #pragma omp parallel for reduction(+:correctPred) num_threads(24)
+    #pragma omp parallel for reduction(+:correctPred)
     for (int i = 0; i < _currentBatchSize; i++) {
         int **activenodesperlayer = new int *[_numberOfLayers + 1]();
         float **activeValuesperlayer = new float *[_numberOfLayers + 1]();


### PR DESCRIPTION
The number of threads should use the default or set with environment
variable OMP_NUM_THREADS.

Signed-off-by: ShinYee <shinyee@speedgocomputing.com>