### PR TITLE
Add "Forks" section into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ cmake ..
 make
 ./runme ../SLIDE/Config_amz.csv
 ```
+
+### Forks
+[GoSLIDE](https://github.com/nlpodyssey/goslide): A Go port of the SLIDE algorithm.


### PR DESCRIPTION
I propose to add a new "Fork" section in the README, to include the [GoSLIDE](https://github.com/nlpodyssey/goslide) Go port I am working on.
